### PR TITLE
:bath: [#145330113] Clean up kernel

### DIFF
--- a/arch/arm/boot/dts/at91sam9g45.dtsi
+++ b/arch/arm/boot/dts/at91sam9g45.dtsi
@@ -34,11 +34,8 @@
 		gpio4 = &pioE;
 		tcb0 = &tcb0;
 		tcb1 = &tcb1;
-		i2c0 = &i2c0;
-		i2c1 = &i2c1;
 		ssc0 = &ssc0;
 		ssc1 = &ssc1;
-		pwm0 = &pwm0;
 	};
 	cpus {
 		#address-cells = <0>;
@@ -65,12 +62,6 @@
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
 			clock-frequency = <0>;
-		};
-
-		adc_op_clk: adc_op_clk{
-			compatible = "fixed-clock";
-			#clock-cells = <0>;
-			clock-frequency = <300000>;
 		};
 	};
 
@@ -322,16 +313,6 @@
 						reg = <18>;
 					};
 
-					pwm_clk: pwm_clk {
-						#clock-cells = <0>;
-						reg = <19>;
-					};
-
-					adc_clk: adc_clk {
-						#clock-cells = <0>;
-						reg = <20>;
-					};
-
 					dma0_clk: dma0_clk {
 						#clock-cells = <0>;
 						reg = <21>;
@@ -444,87 +425,11 @@
 				       0xffffffff 0x81ffff81  /* pioE */
 				      >;
 
-				/* shared pinctrl settings */
-				adc0 {
-					pinctrl_adc0_adtrg: adc0_adtrg {
-						atmel,pins = <AT91_PIOD 28 AT91_PERIPH_A AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad0: adc0_ad0 {
-						atmel,pins = <AT91_PIOD 20 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad1: adc0_ad1 {
-						atmel,pins = <AT91_PIOD 21 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad2: adc0_ad2 {
-						atmel,pins = <AT91_PIOD 22 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad3: adc0_ad3 {
-						atmel,pins = <AT91_PIOD 23 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad4: adc0_ad4 {
-						atmel,pins = <AT91_PIOD 24 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad5: adc0_ad5 {
-						atmel,pins = <AT91_PIOD 25 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad6: adc0_ad6 {
-						atmel,pins = <AT91_PIOD 26 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-					pinctrl_adc0_ad7: adc0_ad7 {
-						atmel,pins = <AT91_PIOD 27 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-				};
-
 				dbgu {
 					pinctrl_dbgu: dbgu-0 {
 						atmel,pins =
 							<AT91_PIOB 12 AT91_PERIPH_A AT91_PINCTRL_PULL_UP
 							 AT91_PIOB 13 AT91_PERIPH_A AT91_PINCTRL_NONE>;
-					};
-				};
-
-				i2c0 {
-					pinctrl_i2c0: i2c0-0 {
-						atmel,pins =
-							<AT91_PIOA 21 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PA21 periph A TWCK0 */
-							 AT91_PIOA 20 AT91_PERIPH_A AT91_PINCTRL_NONE>;	/* PA20 periph A TWD0 */
-					};
-				};
-
-				i2c1 {
-					pinctrl_i2c1: i2c1-0 {
-						atmel,pins =
-							<AT91_PIOB 11 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PB11 periph A TWCK1 */
-							 AT91_PIOB 10 AT91_PERIPH_A AT91_PINCTRL_NONE>;	/* PB10 periph A TWD1 */
-					};
-				};
-
-				isi {
-					pinctrl_isi_data_0_7: isi-0-data-0-7 {
-						atmel,pins =
-							<AT91_PIOB 20 AT91_PERIPH_A AT91_PINCTRL_NONE /* D0 */
-							AT91_PIOB 21 AT91_PERIPH_A AT91_PINCTRL_NONE /* D1 */
-							AT91_PIOB 22 AT91_PERIPH_A AT91_PINCTRL_NONE /* D2 */
-							AT91_PIOB 23 AT91_PERIPH_A AT91_PINCTRL_NONE /* D3 */
-							AT91_PIOB 24 AT91_PERIPH_A AT91_PINCTRL_NONE /* D4 */
-							AT91_PIOB 25 AT91_PERIPH_A AT91_PINCTRL_NONE /* D5 */
-							AT91_PIOB 26 AT91_PERIPH_A AT91_PINCTRL_NONE /* D6 */
-							AT91_PIOB 27 AT91_PERIPH_A AT91_PINCTRL_NONE /* D7 */
-							AT91_PIOB 28 AT91_PERIPH_A AT91_PINCTRL_NONE /* PCK */
-							AT91_PIOB 29 AT91_PERIPH_A AT91_PINCTRL_NONE /* VSYNC */
-							AT91_PIOB 30 AT91_PERIPH_A AT91_PINCTRL_NONE>; /* HSYNC */
-					};
-
-					pinctrl_isi_data_8_9: isi-0-data-8-9 {
-						atmel,pins =
-							<AT91_PIOB 8 AT91_PERIPH_B AT91_PINCTRL_NONE /* D8 */
-							AT91_PIOB 9 AT91_PERIPH_B AT91_PINCTRL_NONE>; /* D9 */
-					};
-
-					pinctrl_isi_data_10_11: isi-0-data-10-11 {
-						atmel,pins =
-							<AT91_PIOB 10 AT91_PERIPH_B AT91_PINCTRL_NONE /* D10 */
-							AT91_PIOB 11 AT91_PERIPH_B AT91_PINCTRL_NONE>; /* D11 */
 					};
 				};
 
@@ -633,54 +538,6 @@
 							 AT91_PIOA 28 AT91_PERIPH_B AT91_PINCTRL_NONE	/* PA28 periph B */
 							 AT91_PIOA 29 AT91_PERIPH_B AT91_PINCTRL_NONE	/* PA29 periph B */
 							 AT91_PIOA 30 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PA30 periph B */
-					};
-				};
-
-				mmc0 {
-					pinctrl_mmc0_slot0_clk_cmd_dat0: mmc0_slot0_clk_cmd_dat0-0 {
-						atmel,pins =
-							<AT91_PIOA 0 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PA0 periph A */
-							 AT91_PIOA 1 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA1 periph A with pullup */
-							 AT91_PIOA 2 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA2 periph A with pullup */
-					};
-
-					pinctrl_mmc0_slot0_dat1_3: mmc0_slot0_dat1_3-0 {
-						atmel,pins =
-							<AT91_PIOA 3 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA3 periph A with pullup */
-							 AT91_PIOA 4 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA4 periph A with pullup */
-							 AT91_PIOA 5 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA5 periph A with pullup */
-					};
-
-					pinctrl_mmc0_slot0_dat4_7: mmc0_slot0_dat4_7-0 {
-						atmel,pins =
-							<AT91_PIOA 6 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA6 periph A with pullup */
-							 AT91_PIOA 7 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA7 periph A with pullup */
-							 AT91_PIOA 8 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA8 periph A with pullup */
-							 AT91_PIOA 9 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA9 periph A with pullup */
-					};
-				};
-
-				mmc1 {
-					pinctrl_mmc1_slot0_clk_cmd_dat0: mmc1_slot0_clk_cmd_dat0-0 {
-						atmel,pins =
-							<AT91_PIOA 31 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PA31 periph A */
-							 AT91_PIOA 22 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA22 periph A with pullup */
-							 AT91_PIOA 23 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA23 periph A with pullup */
-					};
-
-					pinctrl_mmc1_slot0_dat1_3: mmc1_slot0_dat1_3-0 {
-						atmel,pins =
-							<AT91_PIOA 24 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA24 periph A with pullup */
-							 AT91_PIOA 25 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA25 periph A with pullup */
-							 AT91_PIOA 26 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA26 periph A with pullup */
-					};
-
-					pinctrl_mmc1_slot0_dat4_7: mmc1_slot0_dat4_7-0 {
-						atmel,pins =
-							<AT91_PIOA 27 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA27 periph A with pullup */
-							 AT91_PIOA 28 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA28 periph A with pullup */
-							 AT91_PIOA 29 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA29 periph A with pullup */
-							 AT91_PIOA 20 AT91_PERIPH_A AT91_PINCTRL_PULL_UP>;	/* PA30 periph A with pullup */
 					};
 				};
 
@@ -807,42 +664,6 @@
 
 					pinctrl_tcb1_tiob2: tcb1_tiob2-0 {
 						atmel,pins = <AT91_PIOD 8 AT91_PERIPH_B AT91_PINCTRL_NONE>;
-					};
-				};
-
-				fb {
-					pinctrl_fb: fb-0 {
-						atmel,pins =
-							<AT91_PIOE 0 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE0 periph A */
-							 AT91_PIOE 2 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE2 periph A */
-							 AT91_PIOE 3 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE3 periph A */
-							 AT91_PIOE 4 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE4 periph A */
-							 AT91_PIOE 5 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE5 periph A */
-							 AT91_PIOE 6 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE6 periph A */
-							 AT91_PIOE 7 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE7 periph A */
-							 AT91_PIOE 8 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE8 periph A */
-							 AT91_PIOE 9 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE9 periph A */
-							 AT91_PIOE 10 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE10 periph A */
-							 AT91_PIOE 11 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE11 periph A */
-							 AT91_PIOE 12 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE12 periph A */
-							 AT91_PIOE 13 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE13 periph A */
-							 AT91_PIOE 14 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE14 periph A */
-							 AT91_PIOE 15 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE15 periph A */
-							 AT91_PIOE 16 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE16 periph A */
-							 AT91_PIOE 17 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE17 periph A */
-							 AT91_PIOE 18 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE18 periph A */
-							 AT91_PIOE 19 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE19 periph A */
-							 AT91_PIOE 20 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE20 periph A */
-							 AT91_PIOE 21 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE21 periph A */
-							 AT91_PIOE 22 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE22 periph A */
-							 AT91_PIOE 23 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE23 periph A */
-							 AT91_PIOE 24 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE24 periph A */
-							 AT91_PIOE 25 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE25 periph A */
-							 AT91_PIOE 26 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE26 periph A */
-							 AT91_PIOE 27 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE27 periph A */
-							 AT91_PIOE 28 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE28 periph A */
-							 AT91_PIOE 29 AT91_PERIPH_A AT91_PINCTRL_NONE	/* PE29 periph A */
-							 AT91_PIOE 30 AT91_PERIPH_A AT91_PINCTRL_NONE>;	/* PE30 periph A */
 					};
 				};
 
@@ -983,30 +804,6 @@
 				clocks = <&trng_clk>;
 			};
 
-			i2c0: i2c@fff84000 {
-				compatible = "atmel,at91sam9g10-i2c";
-				reg = <0xfff84000 0x100>;
-				interrupts = <12 IRQ_TYPE_LEVEL_HIGH 6>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&pinctrl_i2c0>;
-				#address-cells = <1>;
-				#size-cells = <0>;
-				clocks = <&twi0_clk>;
-				status = "disabled";
-			};
-
-			i2c1: i2c@fff88000 {
-				compatible = "atmel,at91sam9g10-i2c";
-				reg = <0xfff88000 0x100>;
-				interrupts = <13 IRQ_TYPE_LEVEL_HIGH 6>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&pinctrl_i2c1>;
-				#address-cells = <1>;
-				#size-cells = <0>;
-				clocks = <&twi1_clk>;
-				status = "disabled";
-			};
-
 			ssc0: ssc@fff9c000 {
 				compatible = "atmel,at91sam9g45-ssc";
 				reg = <0xfff9c000 0x4000>;
@@ -1026,94 +823,6 @@
 				pinctrl-0 = <&pinctrl_ssc1_tx &pinctrl_ssc1_rx>;
 				clocks = <&ssc1_clk>;
 				clock-names = "pclk";
-				status = "disabled";
-			};
-
-			adc0: adc@fffb0000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-				compatible = "atmel,at91sam9g45-adc";
-				reg = <0xfffb0000 0x100>;
-				interrupts = <20 IRQ_TYPE_LEVEL_HIGH 0>;
-				clocks = <&adc_clk>, <&adc_op_clk>;
-				clock-names = "adc_clk", "adc_op_clk";
-				atmel,adc-channels-used = <0xff>;
-				atmel,adc-vref = <3300>;
-				atmel,adc-startup-time = <40>;
-				atmel,adc-res = <8 10>;
-				atmel,adc-res-names = "lowres", "highres";
-				atmel,adc-use-res = "highres";
-
-				trigger0 {
-					trigger-name = "external-rising";
-					trigger-value = <0x1>;
-					trigger-external;
-				};
-				trigger1 {
-					trigger-name = "external-falling";
-					trigger-value = <0x2>;
-					trigger-external;
-				};
-
-				trigger2 {
-					trigger-name = "external-any";
-					trigger-value = <0x3>;
-					trigger-external;
-				};
-
-				trigger3 {
-					trigger-name = "continuous";
-					trigger-value = <0x6>;
-				};
-			};
-
-			isi@fffb4000 {
-				compatible = "atmel,at91sam9g45-isi";
-				reg = <0xfffb4000 0x4000>;
-				interrupts = <26 IRQ_TYPE_LEVEL_HIGH 5>;
-				clocks = <&isi_clk>;
-				clock-names = "isi_clk";
-				status = "disabled";
-				port {
-					#address-cells = <1>;
-					#size-cells = <0>;
-				};
-			};
-
-			pwm0: pwm@fffb8000 {
-				compatible = "atmel,at91sam9rl-pwm";
-				reg = <0xfffb8000 0x300>;
-				interrupts = <19 IRQ_TYPE_LEVEL_HIGH 4>;
-				#pwm-cells = <3>;
-				clocks = <&pwm_clk>;
-				status = "disabled";
-			};
-
-			mmc0: mmc@fff80000 {
-				compatible = "atmel,hsmci";
-				reg = <0xfff80000 0x600>;
-				interrupts = <11 IRQ_TYPE_LEVEL_HIGH 0>;
-				pinctrl-names = "default";
-				dmas = <&dma 1 AT91_DMA_CFG_PER_ID(0)>;
-				dma-names = "rxtx";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				clocks = <&mci0_clk>;
-				clock-names = "mci_clk";
-				status = "disabled";
-			};
-
-			mmc1: mmc@fffd0000 {
-				compatible = "atmel,hsmci";
-				reg = <0xfffd0000 0x600>;
-				interrupts = <29 IRQ_TYPE_LEVEL_HIGH 0>;
-				pinctrl-names = "default";
-				dmas = <&dma 1 AT91_DMA_CFG_PER_ID(13)>;
-				dma-names = "rxtx";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				clocks = <&mci1_clk>;
-				clock-names = "mci_clk";
 				status = "disabled";
 			};
 
@@ -1267,17 +976,6 @@
 			};
 		};
 
-		fb0: fb@0x00500000 {
-			compatible = "atmel,at91sam9g45-lcdc";
-			reg = <0x00500000 0x1000>;
-			interrupts = <23 IRQ_TYPE_LEVEL_HIGH 3>;
-			pinctrl-names = "default";
-			pinctrl-0 = <&pinctrl_fb>;
-			clocks = <&lcd_clk>, <&lcd_clk>;
-			clock-names = "hclk", "lcdc_clk";
-			status = "disabled";
-		};
-
 		nand0: nand@40000000 {
 			compatible = "atmel,at91rm9200-nand";
 			#address-cells = <1>;
@@ -1314,18 +1012,5 @@
 			clock-names = "usb_clk", "ehci_clk";
 			status = "disabled";
 		};
-	};
-
-	i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		gpios = <&pioA 20 GPIO_ACTIVE_HIGH /* sda */
-			 &pioA 21 GPIO_ACTIVE_HIGH /* scl */
-			>;
-		i2c-gpio,sda-open-drain;
-		i2c-gpio,scl-open-drain;
-		i2c-gpio,delay-us = <5>;	/* ~100 kHz */
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "disabled";
 	};
 };

--- a/arch/arm/boot/dts/at91sam9m10g45ek.dts
+++ b/arch/arm/boot/dts/at91sam9m10g45ek.dts
@@ -8,7 +8,6 @@
  */
 /dts-v1/;
 #include "at91sam9g45.dtsi"
-#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "Atmel AT91SAM9M10G45-EK";
@@ -52,103 +51,8 @@
 				status = "okay";
 			};
 
-			i2c0: i2c@fff84000 {
-				status = "okay";
-				ov2640: camera@30 {
-					compatible = "ovti,ov2640";
-					reg = <0x30>;
-					pinctrl-names = "default";
-					pinctrl-0 = <&pinctrl_pck1_as_isi_mck &pinctrl_sensor_power &pinctrl_sensor_reset>;
-					resetb-gpios = <&pioD 12 GPIO_ACTIVE_LOW>;
-					pwdn-gpios = <&pioD 13 GPIO_ACTIVE_HIGH>;
-					clocks = <&pck1>;
-					clock-names = "xvclk";
-					assigned-clocks = <&pck1>;
-					assigned-clock-rates = <25000000>;
-
-					port {
-						ov2640_0: endpoint {
-							remote-endpoint = <&isi_0>;
-							bus-width = <8>;
-						};
-					};
-				};
-			};
-
-			i2c1: i2c@fff88000 {
-				status = "okay";
-			};
-
 			watchdog@fffffd40 {
 				status = "okay";
-			};
-
-			mmc0: mmc@fff80000 {
-				pinctrl-0 = <
-					&pinctrl_board_mmc0
-					&pinctrl_mmc0_slot0_clk_cmd_dat0
-					&pinctrl_mmc0_slot0_dat1_3>;
-				status = "okay";
-				slot@0 {
-					reg = <0>;
-					bus-width = <4>;
-					cd-gpios = <&pioD 10 GPIO_ACTIVE_HIGH>;
-				};
-			};
-
-			mmc1: mmc@fffd0000 {
-				pinctrl-0 = <
-					&pinctrl_board_mmc1
-					&pinctrl_mmc1_slot0_clk_cmd_dat0
-					&pinctrl_mmc1_slot0_dat1_3>;
-				status = "okay";
-				slot@0 {
-					reg = <0>;
-					bus-width = <4>;
-					cd-gpios = <&pioD 11 GPIO_ACTIVE_HIGH>;
-					wp-gpios = <&pioD 29 GPIO_ACTIVE_HIGH>;
-				};
-			};
-
-			pinctrl@fffff200 {
-				camera_sensor {
-					pinctrl_pck1_as_isi_mck: pck1_as_isi_mck-0 {
-						atmel,pins =
-							<AT91_PIOB 31 AT91_PERIPH_B AT91_PINCTRL_NONE>;
-					};
-
-					pinctrl_sensor_reset: sensor_reset-0 {
-						atmel,pins =
-							<AT91_PIOD 12 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-
-					pinctrl_sensor_power: sensor_power-0 {
-						atmel,pins =
-							<AT91_PIOD 13 AT91_PERIPH_GPIO AT91_PINCTRL_NONE>;
-					};
-				};
-				mmc0 {
-					pinctrl_board_mmc0: mmc0-board {
-						atmel,pins =
-							<AT91_PIOD 10 AT91_PERIPH_GPIO AT91_PINCTRL_PULL_UP_DEGLITCH>;	/* PD10 gpio CD pin pull up and deglitch */
-					};
-				};
-
-				mmc1 {
-					pinctrl_board_mmc1: mmc1-board {
-						atmel,pins =
-							<AT91_PIOD 11 AT91_PERIPH_GPIO AT91_PINCTRL_PULL_UP_DEGLITCH	/* PD11 gpio CD pin pull up and deglitch */
-							 AT91_PIOD 29 AT91_PERIPH_GPIO AT91_PINCTRL_PULL_UP>;	/* PD29 gpio WP pin pull up */
-					};
-				};
-
-				pwm0 {
-					pinctrl_pwm_leds: pwm-led {
-						atmel,pins =
-							<AT91_PIOD 0  AT91_PERIPH_B AT91_PINCTRL_PULL_UP	/* PD0 periph B */
-							 AT91_PIOD 31 AT91_PERIPH_B AT91_PINCTRL_PULL_UP>;	/* PD31 periph B */
-					};
-				};
 			};
 
 			spi0: spi@fffa4000{
@@ -166,42 +70,6 @@
 				status = "okay";
 			};
 
-			adc0: adc@fffb0000 {
-				pinctrl-names = "default";
-				pinctrl-0 = <
-					&pinctrl_adc0_ad0
-					&pinctrl_adc0_ad1
-					&pinctrl_adc0_ad2
-					&pinctrl_adc0_ad3
-					&pinctrl_adc0_ad4
-					&pinctrl_adc0_ad5
-					&pinctrl_adc0_ad6
-					&pinctrl_adc0_ad7>;
-				atmel,adc-ts-wires = <4>;
-				status = "okay";
-			};
-
-			isi@fffb4000 {
-				pinctrl-names = "default";
-				pinctrl-0 = <&pinctrl_isi_data_0_7>;
-				status = "okay";
-				port {
-					isi_0: endpoint {
-						remote-endpoint = <&ov2640_0>;
-						bus-width = <8>;
-						vsync-active = <1>;
-						hsync-active = <1>;
-					};
-				};
-			};
-
-			pwm0: pwm@fffb8000 {
-				status = "okay";
-
-				pinctrl-names = "default";
-				pinctrl-0 = <&pinctrl_pwm_leds>;
-			};
-
 			rtc@fffffd20 {
 				atmel,rtt-rtc-time-reg = <&gpbr 0x0>;
 				status = "okay";
@@ -213,35 +81,6 @@
 
 			rtc@fffffdb0 {
 				status = "okay";
-			};
-		};
-
-		fb0: fb@0x00500000 {
-			display = <&display0>;
-			status = "okay";
-
-			display0: display {
-				bits-per-pixel = <32>;
-				atmel,lcdcon-backlight;
-				atmel,dmacon = <0x1>;
-				atmel,lcdcon2 = <0x80008002>;
-				atmel,guard-time = <9>;
-				atmel,lcd-wiring-mode = "RGB";
-
-				display-timings {
-					native-mode = <&timing0>;
-					timing0: timing0 {
-						clock-frequency = <9000000>;
-						hactive = <480>;
-						vactive = <272>;
-						hback-porch = <1>;
-						hfront-porch = <1>;
-						vback-porch = <40>;
-						vfront-porch = <1>;
-						hsync-len = <45>;
-						vsync-len = <1>;
-					};
-				};
 			};
 		};
 
@@ -298,54 +137,6 @@
 			label = "led2green";
 			gpios = <&pioD 31 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "none";
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-
-		left_click {
-			label = "left_click";
-			gpios = <&pioB 6 GPIO_ACTIVE_LOW>;
-			linux,code = <272>;
-			wakeup-source;
-		};
-
-		right_click {
-			label = "right_click";
-			gpios = <&pioB 7 GPIO_ACTIVE_LOW>;
-			linux,code = <273>;
-			wakeup-source;
-		};
-
-		left {
-			label = "Joystick Left";
-			gpios = <&pioB 14 GPIO_ACTIVE_LOW>;
-			linux,code = <105>;
-		};
-
-		right {
-			label = "Joystick Right";
-			gpios = <&pioB 15 GPIO_ACTIVE_LOW>;
-			linux,code = <106>;
-		};
-
-		up {
-			label = "Joystick Up";
-			gpios = <&pioB 16 GPIO_ACTIVE_LOW>;
-			linux,code = <103>;
-		};
-
-		down {
-			label = "Joystick Down";
-			gpios = <&pioB 17 GPIO_ACTIVE_LOW>;
-			linux,code = <108>;
-		};
-
-		enter {
-			label = "Joystick Press";
-			gpios = <&pioB 18 GPIO_ACTIVE_LOW>;
-			linux,code = <28>;
 		};
 	};
 };


### PR DESCRIPTION
Many stuff's the `at91` processor supports are not used by `Renos`.
These are supported in the kernel `Atmel` supplies, but they should be
removed from the proprietary kernel because they only lead to a larger
image, longer startup times and possible errors. Modified in this
commit:

* `ADC` clauses from `at91sam9m10g45ek.dts` and `at91sam9g45.dtsi`
* `PWM` clauses from `at91sam9m10g45ek.dts` and `at91sam9g45.dtsi`
* `I2C` clauses from `at91sam9m10g45ek.dts` and `at91sam9g45.dtsi`
* `MMC` clauses from `at91sam9m10g45ek.dts` and `at91sam9g45.dtsi`
* `FB` clauses from `at91sam9m10g45ek.dts` and `at91sam9g45.dtsi`
* `Camera` clauses from `at91sam9g45.dtsi`
* `Display` clauses from `at91sam9m10g45ek.dts`
* `Keys` clauses from `at91sam9m10g45ek.dts`

fixes #5