### PR TITLE
[#145335935] kernel: Add support for rs485

### DIFF
--- a/arch/arm/boot/dts/at91sam9g45.dtsi
+++ b/arch/arm/boot/dts/at91sam9g45.dtsi
@@ -23,10 +23,9 @@
 
 	aliases {
 		serial0 = &dbgu;
-		serial1 = &usart0;
-		serial2 = &usart1;
-		serial3 = &usart2;
-		serial4 = &usart3;
+		serial1 = &usart1;
+		serial2 = &usart2;
+		serial3 = &usart3;
 		gpio0 = &pioA;
 		gpio1 = &pioB;
 		gpio2 = &pioC;

--- a/arch/arm/boot/dts/at91sam9m10g45ek.dts
+++ b/arch/arm/boot/dts/at91sam9m10g45ek.dts
@@ -39,10 +39,19 @@
 			};
 
 			usart1: serial@fff90000 {
-				pinctrl-0 =
-					<&pinctrl_usart1
-					 &pinctrl_usart1_rts
-					 &pinctrl_usart1_cts>;
+				pinctrl-0 = <&pinctrl_usart1 &pinctrl_usart1_rts>;
+				linux,rs485-enabled-at-boot-time;
+				status = "okay";
+			};
+
+			usart2: serial@fff94000 {
+				pinctrl-0 = <&pinctrl_usart2>;
+				status = "okay";
+			};
+
+			usart3: serial@fff98000 {
+				pinctrl-0 = <&pinctrl_usart3 &pinctrl_usart3_rts>;
+				linux,rs485-enabled-at-boot-time;
 				status = "okay";
 			};
 


### PR DESCRIPTION
- /dev/ttyS0 = ttl, DEBUG
- /dev/ttyS1 = rs485, SD
- /dev/ttyS2 = ttl, FPGA
- /dev/ttyS3 = rs485, CC